### PR TITLE
flake.nix: Be verbose about the build enviroment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
         };
 
         apps.default = flake-utils.lib.mkApp {
-          drv = self.packages.stdenv.${system}.default;
+          drv = self.packages.stdenv.hostPlatform.${system}.default;
         };
       });
 }


### PR DESCRIPTION
This resolves an evaluation warning since the system allias moved under hostPlatform.