### PR TITLE
Fix for Blocked Sign-In + Auto Login via Chrome Cookie Injection  

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ const {
   components,
 } = require("electron");
 const path = require("node:path");
+const fs = require("fs");
 const { ElectronBlocker } = require("@cliqz/adblocker-electron");
 const fetch = require("cross-fetch"); // required 'fetch'
 
@@ -37,6 +38,11 @@ function createWindow() {
   // mainWindow.webContents.openDevTools()
 }
 
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+// Remove Electron automation fingerprint from Chromium
+app.commandLine.appendSwitch('disable-blink-features', 'AutomationControlled');
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -44,7 +50,48 @@ function createWindow() {
 // before opening any window — otherwise EME calls would reject.
 app.whenReady()
   .then(() => components.whenReady())
-  .then(() => {
+  .then(async () => {
+
+  // Override User-Agent on all outgoing requests so SoundCloud sees Chrome, not Electron
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = CHROME_UA;
+    callback({ requestHeaders: details.requestHeaders });
+  });
+
+  // Inject preload.js into all renderer contexts including webviews
+  session.defaultSession.setPreloads([path.join(__dirname, 'preload.js')]);
+
+  // Inject SoundCloud cookies from cookies.json so we're already logged in
+  const cookiesPath = path.join(__dirname, 'cookies.json');
+  if (fs.existsSync(cookiesPath)) {
+    try {
+      const cookies = JSON.parse(fs.readFileSync(cookiesPath, 'utf8'));
+      for (const cookie of cookies) {
+        try {
+          await session.defaultSession.cookies.set({
+            url: cookie.domain.startsWith('.')
+              ? `https://${cookie.domain.slice(1)}`
+              : `https://${cookie.domain}`,
+            name: cookie.name,
+            value: cookie.value,
+            domain: cookie.domain,
+            path: cookie.path || '/',
+            secure: cookie.secure || false,
+            httpOnly: cookie.httpOnly || false,
+            expirationDate: cookie.expirationDate,
+          });
+        } catch (e) {
+          console.warn(`Failed to set cookie ${cookie.name}:`, e.message);
+        }
+      }
+      console.log(`Injected ${cookies.length} cookies from cookies.json`);
+    } catch (e) {
+      console.error('Failed to load cookies.json:', e.message);
+    }
+  } else {
+    console.warn('cookies.json not found — skipping cookie injection');
+  }
+
   createWindow();
 
   apppath = app.getAppPath();
@@ -54,8 +101,16 @@ app.whenReady()
   mainWindow.webContents.on("dom-ready", () => {
     mainWindow.webContents.send("apppath", apppath);
     mainWindow.webContents.send("userdatapath", app.getPath('userData'));
-    // adblocker
+    // adblocker — whitelist SoundCloud auth domains so login isn't blocked
     ElectronBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
+      blocker.updateFromDiff({
+        added: [
+          '@@||soundcloud.com^',
+          '@@||sndcdn.com^',
+          '@@||api-auth.soundcloud.com^',
+          '@@||api.soundcloud.com^',
+        ]
+      });
       blocker.enableBlockingInSession(session.defaultSession);
     });
   });

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,15 @@
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+Object.defineProperty(navigator, 'webdriver', {
+  get: () => undefined,
+  configurable: true,
+});
+
+Object.defineProperty(navigator, 'userAgent', {
+  get: () => CHROME_UA,
+  configurable: true,
+});
+
+if (!window.chrome) {
+  window.chrome = { runtime: {} };
+}


### PR DESCRIPTION
**Problem**

SoundCloud blocks sign in because Electron exposes bot detection signals by default — `navigator.webdriver = true`, a UA string containing "Electron", and the `--enable-automation` Chromium flag. The bundled adblocker can also interfere with auth endpoints.

**Fix**

After digging through the source files I got it working. 

Replace `main.js` with:
[main.js](https://github.com/user-attachments/files/29108109/main.js)

Replace `preload.js` with:
[preload.js](https://github.com/user-attachments/files/29108126/preload.js)

These strip the bot detection signals and spoof the UA to a standard Chrome string, which stops SoundCloud from blocking the session.

On top of that I added cookie injection support — the app can now read a `cookies.json` file from the project root and load your session automatically on startup, no sign in screen needed.

**How to use the cookie workaround:**
1. Install **Cookie-Editor** in Chrome
2. Go to soundcloud.com while logged in
3. Open Cookie-Editor → Export → JSON → save the file as `cookies.json` in the project root
4. Restart the app — it will load already logged in

Would be great to see these changes merged in. Hope it helps!